### PR TITLE
Issue #13 - Updated Travis and unit test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,37 @@
 language: php
 
-notifications:
-  email:
-    recipients:
-
-sudo: false
-
 cache:
   directories:
     - $HOME/.composer/cache
 
 php:
- - 5.6
+  - 5.6
+  - 7.0
+
+addons:
+  postgresql: "9.3"
 
 env:
- matrix:
-  - DB=pgsql MOODLE_BRANCH=MOODLE_29_STABLE
-  - DB=pgsql MOODLE_BRANCH=MOODLE_30_STABLE
-  - DB=pgsql MOODLE_BRANCH=MOODLE_31_STABLE
-  - DB=pgsql MOODLE_BRANCH=master
-  - DB=mysqli MOODLE_BRANCH=MOODLE_29_STABLE
-  - DB=mysqli MOODLE_BRANCH=MOODLE_30_STABLE
-  - DB=mysqli MOODLE_BRANCH=MOODLE_31_STABLE
-  - DB=mysqli MOODLE_BRANCH=master
+  global:
+    - DB=pgsql # There is not enough database usage to justify full check with mysqli too.
+  matrix:
+    - MOODLE_BRANCH=MOODLE_30_STABLE
+    - MOODLE_BRANCH=MOODLE_31_STABLE
+    - MOODLE_BRANCH=MOODLE_32_STABLE
+    - MOODLE_BRANCH=MOODLE_33_STABLE
+    - MOODLE_BRANCH=master
 
 matrix:
   include:
-    - php: 7.0
-      env: DB=pgsql MOODLE_BRANCH=MOODLE_30_STABLE
-    - php: 7.0
-      env: DB=pgsql MOODLE_BRANCH=MOODLE_31_STABLE
-    - php: 7.0
-      env: DB=pgsql MOODLE_BRANCH=master
-    - php: 7.0
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_30_STABLE
-    - php: 7.0
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_31_STABLE
+    # Test old Moodle in PHP 5.6 only
+    - php: 5.6
+      env: MOODLE_BRANCH=MOODLE_29_STABLE
+    # Test MySQL
     - php: 7.0
       env: DB=mysqli MOODLE_BRANCH=master
+    # Test PHP 7.1
+    - php: 7.1
+      env: MOODLE_BRANCH=master
 
 before_install:
   - cd ../..
@@ -46,7 +40,7 @@ before_install:
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
 
 install:
-  - moodle-plugin-ci install
+  - moodle-plugin-ci install -vvv
 
 script:
   - moodle-plugin-ci phplint

--- a/tests/auth_plugin_test.php
+++ b/tests/auth_plugin_test.php
@@ -901,7 +901,7 @@ class auth_plugin_userkey_testcase extends advanced_testcase {
      * @expectedExceptionMessage Unsupported redirect to http://www.example.com/moodle detected, execution terminated.
      */
     public function test_that_user_logged_in_and_redirected() {
-        global $DB;
+        global $DB, $CFG;
 
         $key = new stdClass();
         $key->value = 'UserLogin';
@@ -913,6 +913,7 @@ class auth_plugin_userkey_testcase extends advanced_testcase {
         $key->timecreated   = time();
         $DB->insert_record('user_private_key', $key);
 
+        $CFG->wwwroot = 'http://www.example.com/moodle';
         $_POST['key'] = 'UserLogin';
         @$this->auth->user_login_userkey();
     }


### PR DESCRIPTION
* Added Moodle 32 and Moodle 33 to Travis.

* Updated Travis to not test mysql in every scenario
Otherwise we are going to have a massive combination of PHP versions, databases and Moodle versions.

* Updated Travis to use Postgres 9.3
Required by Moodle 33+

* Updated test_that_user_logged_in_and_redirected as newer Moodle defaults to different URL.
Newer Moodle unit tests defaults wwwroot to 'https' which is inconsistent with the expected exception. In this case we can just enforce a different `$CFG->wwwroot`