### PR TITLE
Add ability to white list IP addresses to ignore iprestrictions

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -30,6 +30,7 @@ use auth_userkey\userkey_manager_interface;
 require_once($CFG->libdir . "/externallib.php");
 require_once($CFG->libdir.'/authlib.php');
 require_once($CFG->dirroot . '/user/lib.php');
+require_once($CFG->dirroot . '/lib/classes/user.php');
 
 /**
  * User key authentication plugin.
@@ -348,7 +349,7 @@ class auth_plugin_userkey extends auth_plugin_base {
 
         $requiredfieds = ['username', 'email', 'firstname', 'lastname'];
         $missingfields = [];
-        foreach($requiredfieds as $requiredfied) {
+        foreach ($requiredfieds as $requiredfied) {
             if (empty($user[$requiredfied])) {
                 $missingfields[] = $requiredfied;
             }

--- a/auth.php
+++ b/auth.php
@@ -57,6 +57,7 @@ class auth_plugin_userkey extends auth_plugin_base {
         'mappingfield' => self::DEFAULT_MAPPING_FIELD,
         'keylifetime' => 60,
         'iprestriction' => 0,
+        'ipwhitelist' => '',
         'redirecturl' => '',
         'ssourl' => '',
         'createuser' => false,
@@ -347,7 +348,7 @@ class auth_plugin_userkey extends auth_plugin_base {
 
         $requiredfieds = ['username', 'email', 'firstname', 'lastname'];
         $missingfields = [];
-        foreach ($requiredfieds as $requiredfied) {
+        foreach($requiredfieds as $requiredfied) {
             if (empty($user[$requiredfied])) {
                 $missingfields[] = $requiredfied;
             }
@@ -603,14 +604,14 @@ class auth_plugin_userkey extends auth_plugin_base {
 
         $mappingfield = $this->get_mapping_field();
         if ($this->should_create_user() || $this->should_update_user()) {
-            $parameters['firstname'] = new external_value(PARAM_NOTAGS, 'The first name(s) of the user', VALUE_OPTIONAL);
-            $parameters['lastname']  = new external_value(PARAM_NOTAGS, 'The family name of the user', VALUE_OPTIONAL);
+            $parameters['firstname'] = new external_value(core_user::get_property_type('firstname'), 'The first name(s) of the user', VALUE_OPTIONAL);
+            $parameters['lastname']  = new external_value(core_user::get_property_type('lastname'), 'The family name of the user', VALUE_OPTIONAL);
 
             if ($mappingfield != 'email') {
-                $parameters['email'] = new external_value(PARAM_RAW_TRIMMED, 'A valid and unique email address', VALUE_OPTIONAL);
+                $parameters['email'] = new external_value(core_user::get_property_type('email'), 'A valid and unique email address', VALUE_OPTIONAL);
             }
             if ($mappingfield != 'username') {
-                $parameters['username'] = new external_value(PARAM_USERNAME, 'A valid and unique username', VALUE_OPTIONAL);
+                $parameters['username'] = new external_value(core_user::get_property_type('username'), 'A valid and unique username', VALUE_OPTIONAL);
             }
         }
 

--- a/auth.php
+++ b/auth.php
@@ -30,7 +30,6 @@ use auth_userkey\userkey_manager_interface;
 require_once($CFG->libdir . "/externallib.php");
 require_once($CFG->libdir.'/authlib.php');
 require_once($CFG->dirroot . '/user/lib.php');
-require_once($CFG->dirroot . '/lib/classes/user.php');
 
 /**
  * User key authentication plugin.
@@ -605,14 +604,14 @@ class auth_plugin_userkey extends auth_plugin_base {
 
         $mappingfield = $this->get_mapping_field();
         if ($this->should_create_user() || $this->should_update_user()) {
-            $parameters['firstname'] = new external_value(core_user::get_property_type('firstname'), 'The first name(s) of the user', VALUE_OPTIONAL);
-            $parameters['lastname']  = new external_value(core_user::get_property_type('lastname'), 'The family name of the user', VALUE_OPTIONAL);
+            $parameters['firstname'] = new external_value(PARAM_NOTAGS, 'The first name(s) of the user', VALUE_OPTIONAL);
+            $parameters['lastname']  = new external_value(PARAM_NOTAGS, 'The family name of the user', VALUE_OPTIONAL);
 
             if ($mappingfield != 'email') {
-                $parameters['email'] = new external_value(core_user::get_property_type('email'), 'A valid and unique email address', VALUE_OPTIONAL);
+                $parameters['email'] = new external_value(PARAM_RAW_TRIMMED, 'A valid and unique email address', VALUE_OPTIONAL);
             }
             if ($mappingfield != 'username') {
-                $parameters['username'] = new external_value(core_user::get_property_type('username'), 'A valid and unique username', VALUE_OPTIONAL);
+                $parameters['username'] = new external_value(PARAM_USERNAME, 'A valid and unique username', VALUE_OPTIONAL);
             }
         }
 

--- a/classes/core_userkey_manager.php
+++ b/classes/core_userkey_manager.php
@@ -124,8 +124,22 @@ class core_userkey_manager implements userkey_manager_interface {
 
         if ($key->iprestriction) {
             $remoteaddr = getremoteaddr(null);
-            if (empty($remoteaddr) or !address_in_subnet($remoteaddr, $key->iprestriction)) {
-                print_error('ipmismatch');
+            $whitelist = get_config('auth_userkey', 'ipwhitelist');
+            if (!empty($whitelist)) {
+                $ips = explode(';', $whitelist);
+                $whitelisted = false;
+                foreach ($ips as $ip) {
+                    if (address_in_subnet($remoteaddr, $ip)) {
+                        $whitelisted = true;
+                    }
+                }
+                if (!$whitelisted) {
+                    print_error('ipmismatch', 'error', '', null, "Remote address: $remoteaddr\nKey IP: $key->iprestriction");
+                }
+            } else if (empty($remoteaddr) ) {
+                print_error('noip', 'auth_userkey');
+            } else if (!address_in_subnet($remoteaddr, $key->iprestriction)) {
+                print_error('ipmismatch', 'error', '', null, "Remote address: $remoteaddr\nKey IP: $key->iprestriction");
             }
         }
 

--- a/classes/core_userkey_manager.php
+++ b/classes/core_userkey_manager.php
@@ -124,7 +124,13 @@ class core_userkey_manager implements userkey_manager_interface {
 
         if ($key->iprestriction) {
             $remoteaddr = getremoteaddr(null);
-            $whitelist = get_config('auth_userkey', 'ipwhitelist');
+
+            if (isset($this->config->ipwhitelist)) {
+                $whitelist = $this->config->ipwhitelist;
+            } else {
+                $whitelist = false;
+            }
+
             if (empty($remoteaddr) ) {
                 print_error('noip', 'auth_userkey');
             } else if (!empty($whitelist)) {

--- a/classes/core_userkey_manager.php
+++ b/classes/core_userkey_manager.php
@@ -125,7 +125,9 @@ class core_userkey_manager implements userkey_manager_interface {
         if ($key->iprestriction) {
             $remoteaddr = getremoteaddr(null);
             $whitelist = get_config('auth_userkey', 'ipwhitelist');
-            if (!empty($whitelist)) {
+            if (empty($remoteaddr) ) {
+                print_error('noip', 'auth_userkey');
+            } else if (!empty($whitelist)) {
                 $ips = explode(';', $whitelist);
                 $whitelisted = false;
                 foreach ($ips as $ip) {
@@ -136,8 +138,6 @@ class core_userkey_manager implements userkey_manager_interface {
                 if (!$whitelisted) {
                     print_error('ipmismatch', 'error', '', null, "Remote address: $remoteaddr\nKey IP: $key->iprestriction");
                 }
-            } else if (empty($remoteaddr) ) {
-                print_error('noip', 'auth_userkey');
             } else if (!address_in_subnet($remoteaddr, $key->iprestriction)) {
                 print_error('ipmismatch', 'error', '', null, "Remote address: $remoteaddr\nKey IP: $key->iprestriction");
             }

--- a/lang/en/auth_userkey.php
+++ b/lang/en/auth_userkey.php
@@ -29,6 +29,10 @@ $string['mappingfield_desc'] = 'This user field will be used to find relevant us
 $string['iprestriction'] = 'IP restriction';
 $string['iprestriction_desc'] = 'If enabled, a web call has to contain "ip" parameter when requesting login URL.
 A user has to have provided IP to be able to use a key to login to LMS.';
+$string['ipwhitelist'] = 'Whitelist IP ranges';
+$string['ipwhitelist_desc'] = "Ignore IP restrictions if the IP address the token was issued for or the login attempt comes from falls within any of these ranges.
+\nThis can happen when some users reach Moodle or the system issuing login tokens via a private network or DMZ.
+\nIf the route to either the system issuing tokens or this Moodle is via a private address range then set this value to 10.0.0.0/8;172.16.0.0/12;192.168.0.0/16";
 $string['keylifetime'] = 'User key life time';
 $string['keylifetime_desc'] = 'Life time in seconds of the each user login key.';
 $string['incorrectkeylifetime'] = 'User key life time should be a number';

--- a/settings.html
+++ b/settings.html
@@ -50,6 +50,13 @@ $fields = get_auth_plugin('userkey')->get_allowed_mapping_fields();
             <?php print_string($field.'_desc', 'auth_userkey')?></td>
     </tr>
     <tr valign="top">
+        <?php $field = 'ipwhitelist' ?>
+        <td align="right"><label for="<?php echo $field ?>"><?php print_string($field, 'auth_userkey') ?></label></td>
+        <td><input type="text" size="60" name="<?php echo $field ?>" value="<?php print $config->$field ?>" placeholder=""><br>
+            <?php if (isset($err[$field])) { echo $OUTPUT->notification($err[$field], 'notifyfailure'); } ?>
+            <?php print_string($field.'_desc', 'auth_userkey') ?></td>
+    </tr>
+    <tr valign="top">
         <?php $field = 'redirecturl' ?>
         <td align="right"><label for="<?php echo $field ?>"><?php print_string($field, 'auth_userkey') ?></label></td>
         <td><input type="text" size="60" name="<?php echo $field ?>" value="<?php print $config->$field ?>" placeholder=""><br>

--- a/tests/auth_plugin_test.php
+++ b/tests/auth_plugin_test.php
@@ -844,32 +844,6 @@ class auth_plugin_userkey_testcase extends advanced_testcase {
     }
 
     /**
-     * Test that IP address mismatch is ingored if IP is whitelisted.
-     *
-     * @expectedException moodle_exception
-     * @expectedExceptionMessage Unsupported redirect to http://www.example.com/moodle detected, execution terminated.
-     */
-    public function test_ipmismatch_exception_notthrown_if_ip_is_whitelisted() {
-        global $DB;
-
-        set_config('ipwhitelist', '10.0.0.0/8;172.16.0.0/12;192.168.0.0/16', 'auth_userkey');
-
-        $key = new stdClass();
-        $key->value = 'IpmismatchKey';
-        $key->script = 'auth/userkey';
-        $key->userid = $this->user->id;
-        $key->instance = $this->user->id;
-        $key->iprestriction = '192.168.1.1';
-        $key->validuntil    = time() + 300;
-        $key->timecreated   = time();
-        $DB->insert_record('user_private_key', $key);
-
-        $_POST['key'] = 'IpmismatchKey';
-        $_SERVER['HTTP_CLIENT_IP'] = '192.168.1.2';
-        @$this->auth->user_login_userkey();
-    }
-
-    /**
      * Test that IP address mismatch exception gets thrown if incorrect IP and outside whitelist.
      *
      * @expectedException moodle_exception

--- a/tests/auth_plugin_test.php
+++ b/tests/auth_plugin_test.php
@@ -756,6 +756,7 @@ class auth_plugin_userkey_testcase extends advanced_testcase {
         $formconfig->mappingfield = 'email';
         $formconfig->keylifetime = 100;
         $formconfig->iprestriction = 0;
+        $formconfig->ipwhitelist = '';
         $formconfig->redirecturl = 'http://google.com/';
         $formconfig->ssourl = 'http://google.com/';
         $formconfig->createuser = false;
@@ -839,6 +840,84 @@ class auth_plugin_userkey_testcase extends advanced_testcase {
 
         $_POST['key'] = 'IpmismatchKey';
         $_SERVER['HTTP_CLIENT_IP'] = '192.168.1.2';
+        $this->auth->user_login_userkey();
+    }
+
+    /**
+     * Test that IP address mismatch exception gets thrown if incorrect IP.
+     *
+     * @expectedException moodle_exception
+     * @expectedExceptionMessage Unsupported redirect to http://www.example.com/moodle detected, execution terminated.
+     */
+    public function test_ipmismatch_exception_notthrown_if_ip_is_whitelisted() {
+        global $DB;
+
+        set_config('ipwhitelist', '10.0.0.0/8;172.16.0.0/12;192.168.0.0/16', 'auth_userkey');
+
+        $key = new stdClass();
+        $key->value = 'IpmismatchKey';
+        $key->script = 'auth/userkey';
+        $key->userid = $this->user->id;
+        $key->instance = $this->user->id;
+        $key->iprestriction = '192.168.1.1';
+        $key->validuntil    = time() + 300;
+        $key->timecreated   = time();
+        $DB->insert_record('user_private_key', $key);
+
+        $_POST['key'] = 'IpmismatchKey';
+        $_SERVER['HTTP_CLIENT_IP'] = '192.168.1.2';
+        @$this->auth->user_login_userkey();
+    }
+
+    /**
+     * Test that IP address mismatch exception gets thrown if incorrect IP.
+     *
+     * @expectedException moodle_exception
+     * @expectedExceptionMessage Unsupported redirect to http://www.example.com/moodle detected, execution terminated.
+     */
+    public function test_ipmismatch_exception_notthrown_if_ip_is_whitelisted_temp() {
+        global $DB;
+
+        set_config('ipwhitelist', '192.168.1.2', 'auth_userkey');
+
+        $key = new stdClass();
+        $key->value = 'IpmismatchKey';
+        $key->script = 'auth/userkey';
+        $key->userid = $this->user->id;
+        $key->instance = $this->user->id;
+        $key->iprestriction = '192.168.1.1';
+        $key->validuntil    = time() + 300;
+        $key->timecreated   = time();
+        $DB->insert_record('user_private_key', $key);
+
+        $_POST['key'] = 'IpmismatchKey';
+        $_SERVER['HTTP_CLIENT_IP'] = '192.168.1.2';
+        @$this->auth->user_login_userkey();
+    }
+
+    /**
+     * Test that IP address mismatch exception gets thrown if incorrect IP.
+     *
+     * @expectedException moodle_exception
+     * @expectedExceptionMessage Client IP address mismatch
+     */
+    public function test_ipmismatch_exception_thrown_if_ip_is_outside_whitelist() {
+        global $DB;
+
+        set_config('ipwhitelist', '10.0.0.0/8;172.16.0.0/12;192.168.0.0/16', 'auth_userkey');
+
+        $key = new stdClass();
+        $key->value = 'IpmismatchKey';
+        $key->script = 'auth/userkey';
+        $key->userid = $this->user->id;
+        $key->instance = $this->user->id;
+        $key->iprestriction = '192.161.1.1';
+        $key->validuntil    = time() + 300;
+        $key->timecreated   = time();
+        $DB->insert_record('user_private_key', $key);
+
+        $_POST['key'] = 'IpmismatchKey';
+        $_SERVER['HTTP_CLIENT_IP'] = '192.161.1.2';
         $this->auth->user_login_userkey();
     }
 

--- a/tests/auth_plugin_test.php
+++ b/tests/auth_plugin_test.php
@@ -844,7 +844,7 @@ class auth_plugin_userkey_testcase extends advanced_testcase {
     }
 
     /**
-     * Test that IP address mismatch exception gets thrown if incorrect IP.
+     * Test that IP address mismatch is ingored if IP is whitelisted.
      *
      * @expectedException moodle_exception
      * @expectedExceptionMessage Unsupported redirect to http://www.example.com/moodle detected, execution terminated.
@@ -870,33 +870,7 @@ class auth_plugin_userkey_testcase extends advanced_testcase {
     }
 
     /**
-     * Test that IP address mismatch exception gets thrown if incorrect IP.
-     *
-     * @expectedException moodle_exception
-     * @expectedExceptionMessage Unsupported redirect to http://www.example.com/moodle detected, execution terminated.
-     */
-    public function test_ipmismatch_exception_notthrown_if_ip_is_whitelisted_temp() {
-        global $DB;
-
-        set_config('ipwhitelist', '192.168.1.2', 'auth_userkey');
-
-        $key = new stdClass();
-        $key->value = 'IpmismatchKey';
-        $key->script = 'auth/userkey';
-        $key->userid = $this->user->id;
-        $key->instance = $this->user->id;
-        $key->iprestriction = '192.168.1.1';
-        $key->validuntil    = time() + 300;
-        $key->timecreated   = time();
-        $DB->insert_record('user_private_key', $key);
-
-        $_POST['key'] = 'IpmismatchKey';
-        $_SERVER['HTTP_CLIENT_IP'] = '192.168.1.2';
-        @$this->auth->user_login_userkey();
-    }
-
-    /**
-     * Test that IP address mismatch exception gets thrown if incorrect IP.
+     * Test that IP address mismatch exception gets thrown if incorrect IP and outside whitelist.
      *
      * @expectedException moodle_exception
      * @expectedExceptionMessage Client IP address mismatch


### PR DESCRIPTION
This is an enhancement a client required:

The Wordpress site requesting the tokens was running on a server in the clients DMZ and the Moodle was hosted externally, the meant that for internal users the IP detected by Wordpress and to which the login token is locked is on an internal range so when the user then reaches Moodle via a public IP it looks like something dodgy is going on.
This setting allows you to whitelist private address ranges etc. so that you can keep the IP restrictions in place for external users.

Now I've written all that I guess it's a bit of an edge case... I wrote unit tests though...