### PR TITLE
Exclude testing moodle master branch against PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ matrix:
     # Test PHP 7.1
     - php: 7.1
       env: MOODLE_BRANCH=master
+  exclude:
+    - php: 5.6
+      env: MOODLE_BRANCH=master
 
 before_install:
   - cd ../..


### PR DESCRIPTION
The previous build was failing at
```
[Symfony\Component\Process\Exception\ProcessFailedException]
 The command "composer install --no-interaction --prefer-dist" failed.
 Exit Code: 2(Misuse of shell builtins)
 Working directory: /home/travis/build/moodle
 Output:
 ================
 Error Output:
 ================
 Loading composer repositories with package information
 Installing dependencies (including require-dev) from lock file
 Your requirements could not be resolved to an installable set of packages.
 Problem 1
 - Installation request for phpdocumentor/reflection-docblock 4.1.1 -> satisfiable by phpdocumentor/reflection-docblock[4.1.1].
 - phpdocumentor/reflection-docblock 4.1.1 requires php ^7.0 -> your PHP version (5.6.31) does not satisfy that requirement.
 Problem 2
 - Installation request for phpunit/php-token-stream 2.0.1 -> satisfiable by phpunit/php-token-stream[2.0.1].
 - phpunit/php-token-stream 2.0.1 requires php ^7.0 -> your PHP version (5.6.31) does not satisfy that requirement.
 Problem 3
 - phpdocumentor/reflection-docblock 4.1.1 requires php ^7.0 -> your PHP version (5.6.31) does not satisfy that requirement.
 - phpspec/prophecy v1.7.2 requires phpdocumentor/reflection-docblock ^2.0|^3.0.2|^4.0 -> satisfiable by phpdocumentor/reflection-docblock[4.1.1].
 - Installation request for phpspec/prophecy v1.7.2 -> satisfiable by phpspec/prophecy[v1.7.2].
```