### PR TITLE
Added an authentication method restriction.

### DIFF
--- a/lang/en/auth_userkey.php
+++ b/lang/en/auth_userkey.php
@@ -52,3 +52,5 @@ $string['ssourl'] = 'URL of SSO host';
 $string['ssourl_desc'] = 'URL of the SSO host to redirect users to. If defined users will be redirected here on login instead of the Moodle Login page';
 $string['redirecterrordetected'] = 'Unsupported redirect to {$a} detected, execution terminated.';
 $string['noip'] = 'Unable to fetch IP address of client.';
+$string['authtyperestriction'] = 'Auth type restriction.';
+$string['authtyperestriction_desc'] = 'If enabled only users with authentication method set to User key authentication will be able to login or get for a key.';

--- a/settings.php
+++ b/settings.php
@@ -59,4 +59,8 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configselect('auth_userkey/updateuser',
             new lang_string('updateuser', 'auth_userkey'),
             new lang_string('updateuser_desc', 'auth_userkey'), 0, $yesno));
+
+    $settings->add(new admin_setting_configselect('auth_userkey/authtyperestriction',
+        new lang_string('authtyperestriction', 'auth_userkey'),
+        new lang_string('authtyperestriction_desc', 'auth_userkey'), 1, $yesno));
 }


### PR DESCRIPTION
 Depending on new setting web service user will be able to request a user key for all users or only for users with authentication method set to "User key authentication". Same for login in.

I think is useful in case you don't want to delegate authentication for every user.