### PR TITLE
Fix unit tests in auth_plugin_test.php

### DIFF
--- a/tests/auth_plugin_test.php
+++ b/tests/auth_plugin_test.php
@@ -1049,7 +1049,7 @@ class auth_plugin_test extends advanced_testcase {
 
         $this->expectException(moodle_exception::class);
         $this->expectExceptionMessage(
-            sprintf("Unsupported redirect to %s detected, execution terminated.", SELF::REDIRECTION_PATH)
+            sprintf("Unsupported redirect to %s detected, execution terminated.", self::REDIRECTION_PATH)
         );
 
         $this->auth->user_logout_userkey();

--- a/tests/auth_plugin_test.php
+++ b/tests/auth_plugin_test.php
@@ -46,6 +46,12 @@ class auth_plugin_test extends advanced_testcase {
     protected $user;
 
     /**
+     * Path used for the redirection.
+     * @var string
+     */
+    const REDIRECTION_PATH = "/redirection";
+
+    /**
      * Initial set up.
      */
     public function setUp(): void {
@@ -392,7 +398,7 @@ class auth_plugin_test extends advanced_testcase {
 
         self::getDataGenerator()->create_user($originaluser);
 
-        $duplicateuser = clone($originaluser);
+        $duplicateuser = clone ($originaluser);
         $duplicateuser->email = 'duplicateuser@test.com';
 
         $this->expectException(invalid_parameter_exception::class);
@@ -422,7 +428,7 @@ class auth_plugin_test extends advanced_testcase {
 
         self::getDataGenerator()->create_user($originaluser);
 
-        $duplicateuser = clone($originaluser);
+        $duplicateuser = clone ($originaluser);
         $duplicateuser->username = 'duplicateuser';
 
         $this->expectException(invalid_parameter_exception::class);
@@ -1039,10 +1045,12 @@ class auth_plugin_test extends advanced_testcase {
      * Test when try to logout, but user is not logged in.
      */
     public function test_user_logout_userkey_when_user_is_not_logged_in() {
-        $_POST['return'] = 'http://google.com';
+        $_POST['return'] = self::REDIRECTION_PATH;
 
         $this->expectException(moodle_exception::class);
-        $this->expectExceptionMessage('Unsupported redirect to http://google.com detected, execution terminated.');
+        $this->expectExceptionMessage(
+            sprintf("Unsupported redirect to %s detected, execution terminated.", SELF::REDIRECTION_PATH)
+        );
 
         $this->auth->user_logout_userkey();
     }
@@ -1053,7 +1061,7 @@ class auth_plugin_test extends advanced_testcase {
     public function test_user_logout_userkey_when_user_logged_in_with_different_auth() {
         global $USER;
 
-        $_POST['return'] = 'http://google.com';
+        $_POST['return'] = self::REDIRECTION_PATH;
 
         $this->setUser($this->user);
         try {
@@ -1088,14 +1096,16 @@ class auth_plugin_test extends advanced_testcase {
 
         $this->setUser($this->user);
         $USER->auth = 'userkey';
-        $_POST['return'] = 'http://google.com';
+        $_POST['return'] = self::REDIRECTION_PATH;
 
         try {
             $this->auth->user_logout_userkey();
         } catch (moodle_exception $e) {
             $this->assertFalse(isloggedin());
-            $this->assertEquals('Unsupported redirect to http://google.com detected, execution terminated.', $e->getMessage());
+            $this->assertEquals(
+                sprintf('Unsupported redirect to %s detected, execution terminated.', self::REDIRECTION_PATH),
+                $e->getMessage()
+            );
         }
     }
-
 }


### PR DESCRIPTION
Related to this issue [issue 97](https://github.com/catalyst/moodle-auth_userkey/issues/97), a first fix was done by replacing PARAM_URL by PARAM_LOCALURL ([commit](https://github.com/catalyst/moodle-auth_userkey/commit/cd7159628a511a540d7f13f65158402b59bedb11))

Some of the unit tests were broken because of the entire url redirection.
In this PR I replaced the redirection to google by a local redirection. 

To test it:
vendor/bin/phpunit auth/userkey/tests/auth_plugin_test.php

