### PR TITLE
Remove the externallib dependency

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -26,8 +26,8 @@ defined('MOODLE_INTERNAL') || die();
 
 use auth_userkey\core_userkey_manager;
 use auth_userkey\userkey_manager_interface;
+use core_external\external_value;
 
-require_once($CFG->libdir . "/externallib.php");
 require_once($CFG->libdir.'/authlib.php');
 require_once($CFG->dirroot . '/user/lib.php');
 

--- a/externallib.php
+++ b/externallib.php
@@ -24,7 +24,11 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir . "/externallib.php");
+use core_external\external_value;
+use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_single_structure;
+
 require_once($CFG->dirroot . "/webservice/lib.php");
 require_once($CFG->dirroot . "/auth/userkey/auth.php");
 

--- a/tests/auth_plugin_test.php
+++ b/tests/auth_plugin_test.php
@@ -21,7 +21,7 @@ use auth_plugin_userkey;
 use stdClass;
 use invalid_parameter_exception;
 use moodle_exception;
-use external_value;
+use core_external\external_value;
 
 /**
  * Tests for auth_plugin_userkey class.
@@ -57,7 +57,6 @@ class auth_plugin_test extends advanced_testcase {
     public function setUp(): void {
         global $CFG;
 
-        require_once($CFG->libdir . "/externallib.php");
         require_once($CFG->dirroot . '/auth/userkey/tests/fake_userkey_manager.php');
         require_once($CFG->dirroot . '/auth/userkey/auth.php');
         require_once($CFG->dirroot . '/user/lib.php');

--- a/tests/externallib_test.php
+++ b/tests/externallib_test.php
@@ -19,7 +19,7 @@ namespace auth_userkey;
 use advanced_testcase;
 use webservice_access_exception;
 use auth_userkey_external;
-use external_api;
+use core_external\external_api;
 use invalid_parameter_exception;
 use required_capability_exception;
 use context_system;
@@ -37,9 +37,9 @@ class externallib_test extends advanced_testcase {
     /**
      * User object.
      *
-     * @var
+     * @var stdClass
      */
-    protected $user = array();
+    protected $user;
 
     /**
      * Initial set up.
@@ -47,7 +47,6 @@ class externallib_test extends advanced_testcase {
     public function setUp(): void {
         global $CFG;
 
-        require_once($CFG->libdir . "/externallib.php");
         require_once($CFG->dirroot . '/auth/userkey/externallib.php');
 
         $this->resetAfterTest();


### PR DESCRIPTION
Since the version of Moodle 4.2, the unit tests were broken because of the lib/externallib.php. It imposed to isolate the unit tests.
Instead of adding those following annotations as mentioned:
- @runInSeparateProcess
- @runTestsInSeparateProcesses.

I preferred removing the lib/externallib.php dependency.This library will be deprecated soon based on this ticket:
https://tracker.moodle.org/browse/MDL-76583.

Now the unit tests are working correctly.
And we did some manuals tests in our environment and it works correctly. 

**Cette version de code n'est pas compatible avec les versions avant Moodle 4.2**