### PR TITLE
Fix/test time issue

### DIFF
--- a/classes/core_userkey_manager.php
+++ b/classes/core_userkey_manager.php
@@ -16,6 +16,9 @@
 
 namespace auth_userkey;
 
+use core\di;
+use core\clock;
+
 /**
  * Key manager class.
  *
@@ -62,9 +65,9 @@ class core_userkey_manager implements userkey_manager_interface {
         $this->delete_keys($userid);
 
         if (isset($this->config->keylifetime) && (int)$this->config->keylifetime > 0) {
-            $validuntil = time() + $this->config->keylifetime;
+            $validuntil = di::get(clock::class)->time() + $this->config->keylifetime;
         } else {
-            $validuntil = time() + self::DEFAULT_KEY_LIFE_TIME_IN_SECONDS;
+            $validuntil = di::get(clock::class)->time() + self::DEFAULT_KEY_LIFE_TIME_IN_SECONDS;
         }
 
         $iprestriction = null;
@@ -116,7 +119,7 @@ class core_userkey_manager implements userkey_manager_interface {
             throw new \moodle_exception('invalidkey');
         }
 
-        if (!empty($key->validuntil) && $key->validuntil < time()) {
+        if (!empty($key->validuntil) && $key->validuntil < di::get(clock::class)->time()) {
             throw new \moodle_exception('expiredkey');
         }
 

--- a/tests/core_userkey_manager_test.php
+++ b/tests/core_userkey_manager_test.php
@@ -71,6 +71,7 @@ final class core_userkey_manager_test extends \advanced_testcase {
         int $keylifetime = 60
     ): void {
         global $DB;
+        $clock = $this->mock_clock_with_frozen();
         $manager = new core_userkey_manager($this->config);
         if ($allowips) {
             $value = $manager->create_key($this->user->id, $allowips);
@@ -83,7 +84,7 @@ final class core_userkey_manager_test extends \advanced_testcase {
         $this->assertEquals($script, $actualkey->script);
         $this->assertEquals($this->user->id, $actualkey->instance);
         $this->assertEquals($iprestriction, $actualkey->iprestriction);
-        $this->assertEquals(time() + $keylifetime, $actualkey->validuntil);
+        $this->assertEquals($clock->time() + $keylifetime, $actualkey->validuntil);
     }
     /**
      * Test that core_userkey_manager implements userkey_manager_interface interface.


### PR DESCRIPTION
Fix for issue 115:
```
1) auth_userkey\core_userkey_manager_test::test_create_correct_key_if_iprestriction_is_string
Failed asserting that '1765964965' matches expected 1765964966.

/home/runner/work/moodle-auth_userkey/moodle-auth_userkey/moodle/auth/userkey/tests/core_userkey_manager_test.php:86
/home/runner/work/moodle-auth_userkey/moodle-auth_userkey/moodle/auth/userkey/tests/core_userkey_manager_test.php:121
```
By adding a fault tolerance of +/-1 to the test