### PR TITLE
Fix open redirect in user key login

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -140,12 +140,7 @@ class auth_plugin_userkey extends auth_plugin_base {
 
         $keyvalue = required_param('key', PARAM_ALPHANUM);
         $wantsurl = optional_param('wantsurl', '', PARAM_URL);
-
-        if (!empty($wantsurl)) {
-            $redirecturl = $wantsurl;
-        } else {
-            $redirecturl = $CFG->wwwroot;
-        }
+        $redirecturl = $this->get_redirect_url($wantsurl);
 
         try {
             $key = $this->userkeymanager->validate_key($keyvalue);
@@ -671,5 +666,50 @@ class auth_plugin_userkey extends auth_plugin_base {
             // If logged in with different auth type, then display an error.
             throw new moodle_exception('incorrectlogout', 'auth_userkey', $CFG->wwwroot);
         }
+    }
+
+    /**
+     * Returns a safe redirect URL.
+     *
+     * Local Moodle URLs are always allowed. External URLs are allowed only if
+     * their host is included in the configured list of allowed redirect hosts.
+     *
+     * @param string $wantsurl Requested redirect URL.
+     * @return string Safe redirect URL.
+     */
+    protected function get_redirect_url(string $wantsurl): string {
+        global $CFG;
+
+        if (empty($wantsurl)) {
+            return $CFG->wwwroot;
+        }
+
+        $redirecthost = parse_url($wantsurl, PHP_URL_HOST);
+        $localhost = parse_url($CFG->wwwroot, PHP_URL_HOST);
+
+        if (empty($redirecthost) || empty($localhost)) {
+            return $CFG->wwwroot;
+        }
+
+        // Local Moodle URLs are always allowed.
+        if (strcasecmp($redirecthost, $localhost) === 0) {
+            return $wantsurl;
+        }
+
+        if (empty($this->config->allowedredirecthosts)) {
+            return $CFG->wwwroot;
+        }
+
+        $allowedhosts = explode(';', $this->config->allowedredirecthosts);
+
+        foreach ($allowedhosts as $allowedhost) {
+            $allowedhost = trim($allowedhost);
+
+            if ($allowedhost !== '' && strcasecmp($redirecthost, $allowedhost) === 0) {
+                return $wantsurl;
+            }
+        }
+
+        return $CFG->wwwroot;
     }
 }

--- a/lang/en/auth_userkey.php
+++ b/lang/en/auth_userkey.php
@@ -48,6 +48,10 @@ $string['privacy:metadata'] = 'User key authentication plugin does not store any
 $string['redirecterrordetected'] = 'Unsupported redirect to {$a} detected, execution terminated.';
 $string['redirecturl'] = 'Logout redirect URL';
 $string['redirecturl_desc'] = 'Optionally you can redirect users to this URL after they logged out from LMS.';
+$string['allowedredirecthosts'] = 'Allowed redirect hosts';
+$string['allowedredirecthosts_desc'] = "Semicolon-separated list of external hosts that users may be redirected to after key-based authentication. 
+\nEnter host names only, without the protocol or path. For example: portal.example.com;app.example.org. 
+\nLeave empty to prevent redirects to external hosts.";
 $string['ssourl'] = 'URL of SSO host';
 $string['ssourl_desc'] = 'URL of the SSO host to redirect users to. If defined users will be redirected here on login instead of the Moodle Login page';
 $string['updateuser'] = 'Update user?';

--- a/settings.php
+++ b/settings.php
@@ -69,6 +69,14 @@ if ($ADMIN->fulltree) {
     ));
 
     $settings->add(new admin_setting_configtext(
+        'auth_userkey/allowedredirecthosts',
+        get_string('allowedredirecthosts', 'auth_userkey'),
+        get_string('allowedredirecthosts_desc', 'auth_userkey'),
+        '',
+        PARAM_TEXT
+    ));
+
+    $settings->add(new admin_setting_configtext(
         'auth_userkey/ssourl',
         get_string('ssourl', 'auth_userkey'),
         get_string('ssourl_desc', 'auth_userkey', 'auth'),


### PR DESCRIPTION
Fixes #124.

This change restricts external redirects after user key authentication.

External redirect URLs are now allowed only when their host is explicitly configured in the new 'allowedredirecthosts' setting. Local Moodle URLs continue to work without additional configuration.

The setting accepts a semicolon-separated list of allowed hosts, for example:

example.com;example.org

If an external host is not on the allowed list, the user is redirected to the Moodle site instead.
